### PR TITLE
use res.jsonp instead of res.send to enable jsonp support

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -117,7 +117,7 @@ proto = {
   render: function(req, res, view) {
     var index;
     if (req.xhr || req.query.callback) {
-      res.send({
+      res.jsonp({
         view: view,
         data: res.locals
       });

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -78,7 +78,7 @@ proto =
 
     render: (req, res, view) ->
         if req.xhr or req.query.callback
-            res.send
+            res.jsonp
                 view: view
                 data: res.locals
         else


### PR DESCRIPTION
use res.jsonp instead of res.send to enable jsonp support