### PR TITLE
added max-age to serve-static. set default to 365 days

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -15,6 +15,7 @@ config =
     host: '0.0.0.0'
     secret: 'change me'
     hidden: ['secret']
+    max_age: 1000 * 60 * 60 * 24 * 365 # one year
 
 # build.json for deployment time options
 try

--- a/src/middleware.coffee
+++ b/src/middleware.coffee
@@ -14,6 +14,6 @@ app.use bodyParser.json()
 app.use bodyParser.urlencoded extended: true
 app.use methodOverride()
 
-app.use '/static', app.express.static distPath
+app.use '/static', app.express.static distPath, maxAge: app.get 'max_age'
 
 module.exports = app


### PR DESCRIPTION
While the defaults for static-serve use etag, last-modified, and cache-control headers, it sends max-age=0, which can conflict with certain caching systems. This explicitly sets it to 1 year.